### PR TITLE
Dependencies missing

### DIFF
--- a/telescope-theme-iris/package.js
+++ b/telescope-theme-iris/package.js
@@ -13,7 +13,9 @@ Package.onUse(function (api) {
     // core dependencies
     'telescope:core@0.23.0',
     'telescope:theme-base@0.23.0',
-    'telescope:theme-hubble@0.23.0'
+    'telescope:theme-hubble@0.23.0',
+    'telescope:tags@0.23.0',
+    'telescope:notifications@0.23.0'
   ]);
 
   api.use([


### PR DESCRIPTION
This package is actually missing dependencies.  I'm not sure if this is due to the 0.23.0 update, but if you try running telescope and this package via local packages, these overridden templates will be missing and you'll get an error when it tries overriding them in the client.

https://github.com/TelescopeJS/Telescope/blob/1be9c9b0f88d4d4bd39423531badb465333532a8/packages/telescope-notifications/lib/client/templates/notifications_menu.html

https://github.com/TelescopeJS/Telescope/blob/5c9d9670d4c596a6577937e02f28c738369bd413/packages/telescope-tags/lib/client/templates/categories_menu.html

It does not happen when you install via atmosphere and I'm not actually clear why.

I can upload a reproduction if necessary.
